### PR TITLE
Fixed client for use with py34

### DIFF
--- a/pasteraw.py
+++ b/pasteraw.py
@@ -89,7 +89,7 @@ def cli():
         LOG.setLevel(logging.WARN)
 
     if args.version:
-        print pkg_resources.require('pasteraw')[0]
+        print(pkg_resources.require('pasteraw')[0])
         raise SystemExit()
 
     main(args)


### PR DESCRIPTION
This fix updates a single print statement to make the client work
with Py34.

Signed-off-by: Kevin Carter kevin.carter@rackspace.com
